### PR TITLE
log出力の改行に対応

### DIFF
--- a/libs/Utility.py
+++ b/libs/Utility.py
@@ -41,7 +41,11 @@ def getModuleNames(base_path: str) -> list:
 def importAllModules(base_path: str, mod_names: str = None) -> list:
     modules = []
     for name in getModuleNames(base_path) if mod_names is None else mod_names:
-        logger.debug(f"Import module: {name}")
-        modules.append(importlib.import_module(name))
+        try:
+            logger.debug(f"Import module: {name}")
+            modules.append(importlib.import_module(name))
+        except Exception as e:
+            logger.exception(e)
+            pass
 
     return modules

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -1095,7 +1095,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         # 表示しているタブを読み取って、どのコマンドを表示しているか取得、リロード後もそれが選択されるようにする
         oldval_mcu = self.comboBox_MCU.itemText(self.comboBox_MCU.currentIndex())
         oldval_py = self.comboBoxPython.itemText(self.comboBoxPython.currentIndex())
-        print(oldval_mcu)
+        # print(oldval_mcu)
 
         self.comboBox_MCU.clear()
         self.comboBoxPython.clear()
@@ -1200,9 +1200,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def callback_start_command(self, is_alive: bool):
         try:
             if is_alive:
-                print("ALIVE")
+                # print("ALIVE")
+                pass
             else:
-                print("DEAD")
+                # print("DEAD")
+                pass
 
         except Exception as e:
             print(e)

--- a/ui/QtextLogger.py
+++ b/ui/QtextLogger.py
@@ -14,6 +14,7 @@ class QPlainTextEditLogger(logging.Handler):
 
     def emit(self, record):
         msg = self.format(record)
+        msg = msg.replace("\n", "<br>")
         # self.widget.appendPlainText(msg)
         if "ERROR" in str(msg) or "CRITICAL" in str(msg) or "FATAL" in str(msg):
             self.widget.appendHtml(f"<span style=\"color:#ff0000;\" > {msg} </span>")
@@ -25,10 +26,10 @@ class MyDialog(QtWidgets.QMdiSubWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        logTextBox = QPlainTextEditLogger(self)
+        log_text_box = QPlainTextEditLogger(self)
         # You can format what is printed to text box
-        logTextBox.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
-        logging.getLogger().addHandler(logTextBox)
+        log_text_box.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+        logging.getLogger().addHandler(log_text_box)
         # You can control the logging level
         logging.getLogger().setLevel(logging.DEBUG)
 
@@ -37,7 +38,7 @@ class MyDialog(QtWidgets.QMdiSubWindow):
 
         layout = QtWidgets.QVBoxLayout()
         # Add the new logging box widget to the layout
-        layout.addWidget(logTextBox.widget)
+        layout.addWidget(log_text_box.widget)
         layout.addWidget(self._button)
         self.setLayout(layout)
 


### PR DESCRIPTION
- QPlainTextEditへのテキスト追加時に`appendHtml()`を利用している。\
この関係で`\n`ではなく`<br>`が改行となるため、`\n`を`<br>`に置き換えている。

ただし、
```python3
print("\\n hoge")
>>>\n hoge
```
は
```python3
self.debug("\\n hoge")
>>>\
 hoge
```
となるので注意。